### PR TITLE
[TH] change calls to v2 specifications

### DIFF
--- a/lib/google-civic/client.rb
+++ b/lib/google-civic/client.rb
@@ -30,7 +30,7 @@ module GoogleCivic
     # @example List information around the voter
     #   GoogleCivic.voter_info(200, '1263 Pacific Ave. Kansas City KS')
     def voter_info(election_id, address, options={})
-      post("voterinfo/#{election_id}/lookup", {address: address}, options)
+      get("voterinfo", {electionId: election_id, address: address}.merge(options))
     end
 
     # Looks up political geography and (optionally) representative information based on an address
@@ -42,7 +42,7 @@ module GoogleCivic
     # @example List information about the representatives
     #   GoogleCivic.representative_info('1263 Pacific Ave. Kansas City KS')
     def representative_info(address, options={})
-      post("representatives/lookup", {address: address}, options)
+      get("representatives", {address: address}.merge(options))
     end
 
   end

--- a/lib/google-civic/connection.rb
+++ b/lib/google-civic/connection.rb
@@ -6,9 +6,10 @@ module GoogleCivic
     private
 
     def connection(options={})
-      connection = Faraday.new(options.merge({:url => 'https://www.googleapis.com/civicinfo/us_v1/'})) do |builder|
+      connection = Faraday.new(options.merge({:url => 'https://www.googleapis.com/civicinfo/v2/'})) do |builder|
         builder.request :json
         builder.request :url_encoded
+        builder.response :logger
         builder.use FaradayMiddleware::Mashify
         builder.use FaradayMiddleware::ParseJson
         builder.adapter  Faraday.default_adapter

--- a/lib/google-civic/request.rb
+++ b/lib/google-civic/request.rb
@@ -2,20 +2,11 @@ require 'multi_json'
 
 module GoogleCivic
   module Request
-    def get(path,options={})
-      request(:get, path, body=nil, options)
-    end
-
-    def post(path, body, options={})
-      request(:post, path, body, options)
-    end
-
-    private
-
-    def request(method, path, body, options)
-      response = connection.send(method) do |request|
-        request.url(path,  options.merge(:key => @key))
-        request.body = body.to_json
+    def get(path,params={})
+      response = connection.get do |request|
+        request.url path
+        params.each { |name, value| request.params[name] = value }
+        request.params['key'] = @key
       end
       response.body
     end

--- a/spec/google-civic/client_spec.rb
+++ b/spec/google-civic/client_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 describe GoogleCivic::Client do
   it 'should work with an api key' do
-    stub_get("https://www.googleapis.com/civicinfo/us_v1/elections?key=abc123").
+    stub_get("https://www.googleapis.com/civicinfo/v2/elections?key=abc123").
       with(:headers => {'Accept'=>'*/*'}).
       to_return(:status => 200, :body => '', :headers => {})
     proc {
@@ -25,17 +25,15 @@ describe GoogleCivic::Client do
 
   describe "#voter_info" do
     it "should return the voter information from an address" do
-      stub_post("/voterinfo/2000/lookup?key=abc123").
-       with(:body => "{\"address\":\"1263 Pacific Ave. Kansas City KS\"}").
-        to_return(:status => 200, :body => fixture("voter_info.json"), :headers => {})
+      stub_get("/voterinfo?electionId=2000&address=1263+Pacific+Ave.+Kansas+City+KS&key=abc123").
+       to_return(:status => 200, :body => fixture("voter_info.json"), :headers => {})
       voter_info = @client.voter_info(2000, "1263 Pacific Ave. Kansas City KS")
       voter_info.election.name.should eql "VIP Test Election"
     end
 
     it "should take a query parameter" do
-      stub_post("/voterinfo/2000/lookup?includeOffices=true&key=abc123").
-       with(:body => "{\"address\":\"1263 Pacific Ave. Kansas City KS\"}").
-        to_return(:status => 200, :body => fixture("voter_info.json"), :headers => {})
+      stub_get("/voterinfo?electionId=2000&address=1263+Pacific+Ave.+Kansas+City+KS&includeOffices=true&key=abc123").
+       to_return(:status => 200, :body => fixture("voter_info.json"), :headers => {})
       voter_info = @client.voter_info(2000, "1263 Pacific Ave. Kansas City KS", {includeOffices: true})
       voter_info.election.name.should eql "VIP Test Election"
     end
@@ -43,9 +41,8 @@ describe GoogleCivic::Client do
 
   describe "#representative_info" do
     it "should return the representative information from an address" do
-     stub_post("/representatives/lookup?key=abc123").
-       with(:body => "{\"address\":\"1263 Pacific Ave. Kansas City KS\"}").
-        to_return(:status => 200, :body => fixture("representative.json"), :headers => {})
+     stub_get("/representatives?address=1263+Pacific+Ave.+Kansas+City+KS&key=abc123").
+       to_return(:status => 200, :body => fixture("representative.json"), :headers => {})
       rep_info = @client.representative_info("1263 Pacific Ave. Kansas City KS")
       rep_info.offices.first[1].name.should eql "United States House of Representatives KS-03"
     end

--- a/spec/google-civic_spec.rb
+++ b/spec/google-civic_spec.rb
@@ -4,7 +4,7 @@ require 'helper'
 describe GoogleCivic do
   describe ".respond_to?" do
     it "should be true if method exists" do
-      GoogleCivic.respond_to?(:new, true).should be_true
+      GoogleCivic.respond_to?(:new, true).should be_truthy
     end
   end
 
@@ -16,7 +16,7 @@ describe GoogleCivic do
 
   describe ".delegate" do
     it "should delegate missing methods to GoogleCivic::Client" do
-      stub_get("/elections?key").
+      stub_get("/elections?key=").
         to_return(:status => 200, :body => fixture("elections.json"), :headers => {})
       elections = GoogleCivic.elections
       elections.first.should == ["kind", "civicinfo#electionsqueryresponse"]

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -57,5 +57,5 @@ def fixture(file)
 end
 
 def google_url(url)
-  "https://www.googleapis.com/civicinfo/us_v1#{url}"
+  "https://www.googleapis.com/civicinfo/v2#{url}"
 end


### PR DESCRIPTION
I guess I did this work before we decided not to use the upgraded v2 API. Now that it's a requirement, time to dust this off I suppose. What doesn't seem to be accounted for yet is changes in the output of the API, but I don't think that's really the area of this gem, it should just return what the API does and callers should adjust accordingly.

Assigning to @cap10morgan 
