### PR TITLE
Backoff retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ test/version_tmp
 tmp
 tmtags
 tramp
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ Make sure to obtain your API key from here [https://developers.google.com/civic-
     b = @client.voter_info(2000, '1263 Pacific Ave. Kansas City KS')
     b.pollingLocations.first.address # => #<Hashie::Mash city="Kansas City" line1="100 S 20th St" line2="" line3="" locationName="National Guard Armory" state="KS" zip="66102 ">
 
+    # Voter info with backoff retries (up to 6 calls, 2 second pause between each, see below)
+    b = @client.voter_info(2000, '1263 Pacific Ave. Kansas City KS', {connection: {retry: {max: 5, interval: 2}}})
+
+## Backoff Retries
+All of the client methods now take an optional `:connection` hash in the options. These options
+will be passed through to the connection. Additionally, options under a `:retry` symbol key will trigger
+the use of backoff retries. You can use the following retry parameters:
+
+* `:max` - the maximum number of retries (default: 2)
+* `:interval` - the pause in seconds between retries (default: 0)
+* `:interval_randomness` - the maximum random interval amount expressed as a float between 0 and 1 in addition to the interval (default: 0)
+* `:max_interval` - an upper limit for the interval (default: Float::MAX)
+* `:backoff_factor` - the amount to multiply each successive retry's interval amount by in order to provide backoff (default: 1)
+
+The retries are triggered by use of a customized exception and config for the Faraday::Request::Retry middleware. As such, use of the `:exceptions` is not allowed, use of `:methods` isn't needed (all the requests to the API are GET), and use of `:retry_if` might work but hasn't been tested.
+
 ## Contributing
 In the spirit of [free software][free-sw], **everyone** is encouraged to help improve
 this project.

--- a/lib/google-civic.rb
+++ b/lib/google-civic.rb
@@ -1,4 +1,5 @@
 require 'google-civic/client'
+require 'google-civic/error_on_retriable_response'
 
 module GoogleCivic
   class << self

--- a/lib/google-civic/client.rb
+++ b/lib/google-civic/client.rb
@@ -11,38 +11,44 @@ module GoogleCivic
     include GoogleCivic::Request
 
     # Gets a list of elections in the API
-    #
+    # @param options [Hash] A customizable set of options for the request. Any options for the
+    # connection should be nested inside under the key `:connection`.
     # @return [Hashie::Mash] A list of current elections in the API
     # @see https://developers.google.com/civic-information/docs/us_v1/elections/electionQuery
     # @example List the current elections
     #   GoogleCivic.elections
     def elections(options={})
-      get("elections", options)
+      connection_options = options.delete(:connection) {|el| {}}
+      get("elections", options, connection_options)
     end
 
     # Looks up information relevant to a voter based on the voter's registered address.
     #
     # @param election_id [Integer] The id of the election found in .elections
     # @param address [String] The address to search on.
-    # @param options [Hash] A customizable set of options.
+    # @param options [Hash] A customizable set of options for the request. Any options for the
+    # connection should be nested inside under the key `:connection`.
     # @return [Hashie::Mash] A list of current information around the voter
     # @see https://developers.google.com/civic-information/docs/us_v1/elections/voterInfoQuery
     # @example List information around the voter
     #   GoogleCivic.voter_info(200, '1263 Pacific Ave. Kansas City KS')
     def voter_info(election_id, address, options={})
-      get("voterinfo", {electionId: election_id, address: address}.merge(options))
+      connection_options = options.delete(:connection) {|el| {}}
+      get("voterinfo", {electionId: election_id, address: address}.merge(options), connection_options)
     end
 
     # Looks up political geography and (optionally) representative information based on an address
     #
     # @param address [String] The address to search on.
-    # @param options [Hash] A customizable set of options.
+    # @param options [Hash] A customizable set of options for the request. Any options for the
+    # connection should be nested inside under the key `:connection`.
     # @return [Hashie::Mash] A list of current information about representatives
     # @see https://developers.google.com/civic-information/docs/us_v1/representatives/representativeInfoQuery
     # @example List information about the representatives
     #   GoogleCivic.representative_info('1263 Pacific Ave. Kansas City KS')
     def representative_info(address, options={})
-      get("representatives", {address: address}.merge(options))
+      connection_options = options.delete(:connection) {|el| {}}
+      get("representatives", {address: address}.merge(options), connection_options)
     end
 
   end

--- a/lib/google-civic/client.rb
+++ b/lib/google-civic/client.rb
@@ -18,7 +18,7 @@ module GoogleCivic
     # @example List the current elections
     #   GoogleCivic.elections
     def elections(options={})
-      connection_options = options.delete(:connection) {|el| {}}
+      connection_options = options.delete(:connection) {|_| {}}
       get("elections", options, connection_options)
     end
 
@@ -33,7 +33,7 @@ module GoogleCivic
     # @example List information around the voter
     #   GoogleCivic.voter_info(200, '1263 Pacific Ave. Kansas City KS')
     def voter_info(election_id, address, options={})
-      connection_options = options.delete(:connection) {|el| {}}
+      connection_options = options.delete(:connection) {|_| {}}
       get("voterinfo", {electionId: election_id, address: address}.merge(options), connection_options)
     end
 
@@ -47,7 +47,7 @@ module GoogleCivic
     # @example List information about the representatives
     #   GoogleCivic.representative_info('1263 Pacific Ave. Kansas City KS')
     def representative_info(address, options={})
-      connection_options = options.delete(:connection) {|el| {}}
+      connection_options = options.delete(:connection) {|_| {}}
       get("representatives", {address: address}.merge(options), connection_options)
     end
 

--- a/lib/google-civic/connection.rb
+++ b/lib/google-civic/connection.rb
@@ -5,13 +5,26 @@ module GoogleCivic
   module Connection
     private
 
+    def setup_retry(options)
+      retry_options = options.delete(:retry) {|_| {}}
+      unless retry_options.empty?
+        retry_options[:exceptions] = [GoogleCivic::RetriableError]
+      end
+      retry_options
+    end
+
     def connection(options={})
+      retry_options = setup_retry(options)
+      using_retry = !retry_options.empty?
       connection = Faraday.new(options.merge({:url => 'https://www.googleapis.com/civicinfo/v2/'})) do |builder|
         builder.request :json
         builder.request :url_encoded
+        builder.use GoogleCivic::RetriesExhausted if using_retry
+        builder.request(:retry, retry_options) if using_retry
         builder.response :logger
         builder.use FaradayMiddleware::Mashify
         builder.use FaradayMiddleware::ParseJson
+        builder.use GoogleCivic::ErrorOnRetriableResponse if using_retry
         builder.adapter  Faraday.default_adapter
       end
       connection

--- a/lib/google-civic/error_on_retriable_response.rb
+++ b/lib/google-civic/error_on_retriable_response.rb
@@ -1,0 +1,76 @@
+module GoogleCivic
+
+  class RetriableError < Exception
+  	attr_reader :env, :response
+
+  	def initialize(env)
+  	  @env = env
+  	end
+  end
+
+  class ErrorOnRetriableResponse < Faraday::Middleware
+
+  	SERVER_ERROR_CODES = (500...600)
+
+  	TEMPORARY_REASONS = Set.new(["concurrentLimitExceeded", "rateLimitExceeded",
+  		 						 "servingLimitExceeded", "userRateLimitExceeded"])
+
+  	def initialize(app, options={})
+  	  super(app)
+  	end
+
+  	def call(env)
+  	  response = @app.call(env)
+  	  response.on_complete do |response_env|
+  	  	if retriable_error?(response)
+  	  	  raise GoogleCivic::RetriableError.new(response_env)
+  	  	end
+  	  end
+  	end
+
+  	def retriable_error?(response)
+  	  server_error?(response.status) or
+  	  temporary_rate_limit?(response)
+  	end
+
+  	def server_error?(status)
+  	  SERVER_ERROR_CODES.include? status
+  	end
+
+  	def temporary_rate_limit?(response)
+  	  if response.status == 403
+  	  	body = ::Hashie::Mash.new(::JSON.parse(response.body))
+  	  	if body.error? and body.error.errors?
+  	  	  reasons = Set.new body.error.errors.collect(&:reason)
+  	  	  TEMPORARY_REASONS.superset?(reasons)
+  	  	else
+  	  	  false
+  	  	end
+  	  else
+  	  	false
+  	  end
+  	end
+  end
+
+  class RetriesExhausted < Faraday::Middleware
+
+  	dependency do
+      require 'json' unless defined?(::JSON)
+      require 'hashie/mash'
+    end
+
+  	def initialize(app, options={})
+  	  super(app)
+  	end
+
+  	def call(env)
+  	  begin
+  	  	response = @app.call(env)
+  	  rescue GoogleCivic::RetriableError => err
+  	  	response = ::Hashie::Mash.new({status: err.env.status, headers: err.env.response_headers,
+  	  				   			       body: ::JSON.parse(err.env.body)})
+  	  end
+  	  response
+  	end
+  end
+end

--- a/lib/google-civic/error_on_retriable_response.rb
+++ b/lib/google-civic/error_on_retriable_response.rb
@@ -1,76 +1,76 @@
 module GoogleCivic
 
   class RetriableError < Exception
-  	attr_reader :env, :response
+    attr_reader :env, :response
 
-  	def initialize(env)
-  	  @env = env
-  	end
+    def initialize(env)
+      @env = env
+    end
   end
 
   class ErrorOnRetriableResponse < Faraday::Middleware
 
-  	SERVER_ERROR_CODES = (500...600)
+    SERVER_ERROR_CODES = (500...600)
 
-  	TEMPORARY_REASONS = Set.new(["concurrentLimitExceeded", "rateLimitExceeded",
-  		 						 "servingLimitExceeded", "userRateLimitExceeded"])
+    TEMPORARY_REASONS = Set.new(["concurrentLimitExceeded", "rateLimitExceeded",
+                                 "servingLimitExceeded", "userRateLimitExceeded"])
 
-  	def initialize(app, options={})
-  	  super(app)
-  	end
+    def initialize(app)
+      super(app)
+    end
 
-  	def call(env)
-  	  response = @app.call(env)
-  	  response.on_complete do |response_env|
-  	  	if retriable_error?(response)
-  	  	  raise GoogleCivic::RetriableError.new(response_env)
-  	  	end
-  	  end
-  	end
+    def call(env)
+      response = @app.call(env)
+      response.on_complete do |response_env|
+        if retriable_error?(response)
+          raise GoogleCivic::RetriableError.new(response_env)
+        end
+      end
+    end
 
-  	def retriable_error?(response)
-  	  server_error?(response.status) or
-  	  temporary_rate_limit?(response)
-  	end
+    def retriable_error?(response)
+      server_error?(response.status) or
+      temporary_rate_limit?(response)
+    end
 
-  	def server_error?(status)
-  	  SERVER_ERROR_CODES.include? status
-  	end
+    def server_error?(status)
+      SERVER_ERROR_CODES.include? status
+    end
 
-  	def temporary_rate_limit?(response)
-  	  if response.status == 403
-  	  	body = ::Hashie::Mash.new(::JSON.parse(response.body))
-  	  	if body.error? and body.error.errors?
-  	  	  reasons = Set.new body.error.errors.collect(&:reason)
-  	  	  TEMPORARY_REASONS.superset?(reasons)
-  	  	else
-  	  	  false
-  	  	end
-  	  else
-  	  	false
-  	  end
-  	end
+    def temporary_rate_limit?(response)
+      if response.status == 403
+        body = ::Hashie::Mash.new(::JSON.parse(response.body))
+        if body.error? && body.error.errors?
+          reasons = Set.new body.error.errors.collect(&:reason)
+          TEMPORARY_REASONS.superset?(reasons)
+        else
+          false
+        end
+      else
+        false
+      end
+    end
   end
 
   class RetriesExhausted < Faraday::Middleware
 
-  	dependency do
+    dependency do
       require 'json' unless defined?(::JSON)
       require 'hashie/mash'
     end
 
-  	def initialize(app, options={})
-  	  super(app)
-  	end
+    def initialize(app)
+      super(app)
+    end
 
-  	def call(env)
-  	  begin
-  	  	response = @app.call(env)
-  	  rescue GoogleCivic::RetriableError => err
-  	  	response = ::Hashie::Mash.new({status: err.env.status, headers: err.env.response_headers,
-  	  				   			       body: ::JSON.parse(err.env.body)})
-  	  end
-  	  response
-  	end
+    def call(env)
+      begin
+        response = @app.call(env)
+      rescue GoogleCivic::RetriableError => err
+        response = ::Hashie::Mash.new({status: err.env.status, headers: err.env.response_headers,
+                                       body: ::JSON.parse(err.env.body)})
+      end
+      response
+    end
   end
 end

--- a/lib/google-civic/request.rb
+++ b/lib/google-civic/request.rb
@@ -2,8 +2,8 @@ require 'multi_json'
 
 module GoogleCivic
   module Request
-    def get(path,params={})
-      response = connection.get do |request|
+    def get(path,params={},connection_opts={})
+      response = connection(connection_opts).get do |request|
         request.url path
         params.each { |name, value| request.params[name] = value }
         request.params['key'] = @key

--- a/lib/google-civic/version.rb
+++ b/lib/google-civic/version.rb
@@ -1,3 +1,3 @@
 module GoogleCivic
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end

--- a/spec/fixtures/non_retriable_error.json
+++ b/spec/fixtures/non_retriable_error.json
@@ -1,0 +1,13 @@
+{
+ "error": {
+  "errors": [
+   {
+    "domain": "global",
+    "reason": "quotaExceeded",
+    "message": "The quota has been exceeded"
+   }
+  ],
+  "code": 403,
+  "message": "maximum quota reached"
+ }
+}

--- a/spec/fixtures/non_retriable_error_different.json
+++ b/spec/fixtures/non_retriable_error_different.json
@@ -1,0 +1,13 @@
+{
+ "error": {
+  "errors": [
+   {
+    "domain": "global",
+    "reason": "quotaExceeded",
+    "message": "The quota has been exceeded, STAHP!"
+   }
+  ],
+  "code": 403,
+  "message": "maximum quota reached, STAHP!"
+ }
+}

--- a/spec/fixtures/retriable_error.json
+++ b/spec/fixtures/retriable_error.json
@@ -1,0 +1,13 @@
+{
+ "error": {
+  "errors": [
+   {
+    "domain": "global",
+    "reason": "rateLimitExceeded",
+    "message": "The rate limit has currently been exceeded."
+   }
+  ],
+  "code": 403,
+  "message": "The rate limit has currently been exceeded."
+ }
+}

--- a/spec/fixtures/server_error.json
+++ b/spec/fixtures/server_error.json
@@ -1,0 +1,13 @@
+{
+ "error": {
+  "errors": [
+   {
+    "domain": "global",
+    "reason": "internalError",
+    "message": "An internal error has occured."
+   }
+  ],
+  "code": 500,
+  "message": "An internal error has occured."
+ }
+}

--- a/spec/fixtures/server_error_different.json
+++ b/spec/fixtures/server_error_different.json
@@ -1,0 +1,13 @@
+{
+ "error": {
+  "errors": [
+   {
+    "domain": "global",
+    "reason": "internalError",
+    "message": "A different internal error has occured."
+   }
+  ],
+  "code": 502,
+  "message": "A different internal error has occured."
+ }
+}

--- a/spec/google-civic/client_spec.rb
+++ b/spec/google-civic/client_spec.rb
@@ -61,17 +61,20 @@ describe GoogleCivic::Client do
       stub_get("/voterinfo?electionId=2000&address=1263+Pacific+Ave.+Kansas+City+KS&key=abc123").
        to_return({:status => 500, :body => fixture("server_error.json")},
                  {:status => 500, :body => fixture("server_error.json")},
-                 {:status => 500, :body => fixture("server_error.json")})
+                 {:status => 502, :body => fixture("server_error_different.json")})
       voter_info = @client.voter_info(2000, "1263 Pacific Ave. Kansas City KS", {connection: {retry: retry_config}})
-      voter_info.error.code.should eql 500
+      voter_info.error.code.should eql 502
+      voter_info.error.message.should eql "A different internal error has occured."
     end
 
     it "should not retry on a non-retriable error" do
       retry_config = {max: 2, interval: 1}
       stub_get("/voterinfo?electionId=2000&address=1263+Pacific+Ave.+Kansas+City+KS&key=abc123").
-       to_return({:status => 403, :body => fixture("non_retriable_error.json")})
+       to_return({:status => 403, :body => fixture("non_retriable_error.json")},
+                 {:status => 403, :body => fixture("non_retriable_error_different.json")})
       voter_info = @client.voter_info(2000, "1263 Pacific Ave. Kansas City KS", {connection: {retry: retry_config}})
       voter_info.error.code.should eql 403
+      voter_info.error.message.should eql "maximum quota reached"
     end
 
   end

--- a/spec/google-civic/client_spec.rb
+++ b/spec/google-civic/client_spec.rb
@@ -37,6 +37,43 @@ describe GoogleCivic::Client do
       voter_info = @client.voter_info(2000, "1263 Pacific Ave. Kansas City KS", {includeOffices: true})
       voter_info.election.name.should eql "VIP Test Election"
     end
+
+    it "should retry on server error when connection_options includes retry config" do
+      retry_config = {max: 10, interval: 2}
+      stub_get("/voterinfo?electionId=2000&address=1263+Pacific+Ave.+Kansas+City+KS&key=abc123").
+       to_return({:status => 500, :body => fixture("server_error.json")},
+                 {:status => 200, :body => fixture("voter_info.json")})
+      voter_info = @client.voter_info(2000, "1263 Pacific Ave. Kansas City KS", {connection: {retry: retry_config}})
+      voter_info.election.name.should eql "VIP Test Election"
+    end
+
+    it "should retry on retriable error when connection_options includes retry config" do
+      retry_config = {max: 10, interval: 2}
+      stub_get("/voterinfo?electionId=2000&address=1263+Pacific+Ave.+Kansas+City+KS&key=abc123").
+       to_return({:status => 403, :body => fixture("retriable_error.json")},
+                 {:status => 200, :body => fixture("voter_info.json")})
+      voter_info = @client.voter_info(2000, "1263 Pacific Ave. Kansas City KS", {connection: {retry: retry_config}})
+      voter_info.election.name.should eql "VIP Test Election"
+    end
+
+    it "should not retry more than the count" do
+      retry_config = {max: 2, interval: 1}
+      stub_get("/voterinfo?electionId=2000&address=1263+Pacific+Ave.+Kansas+City+KS&key=abc123").
+       to_return({:status => 500, :body => fixture("server_error.json")},
+                 {:status => 500, :body => fixture("server_error.json")},
+                 {:status => 500, :body => fixture("server_error.json")})
+      voter_info = @client.voter_info(2000, "1263 Pacific Ave. Kansas City KS", {connection: {retry: retry_config}})
+      voter_info.error.code.should eql 500
+    end
+
+    it "should not retry on a non-retriable error" do
+      retry_config = {max: 2, interval: 1}
+      stub_get("/voterinfo?electionId=2000&address=1263+Pacific+Ave.+Kansas+City+KS&key=abc123").
+       to_return({:status => 403, :body => fixture("non_retriable_error.json")})
+      voter_info = @client.voter_info(2000, "1263 Pacific Ave. Kansas City KS", {connection: {retry: retry_config}})
+      voter_info.error.code.should eql 403
+    end
+
   end
 
   describe "#representative_info" do


### PR DESCRIPTION
Adds backoff retry capabilities to the gem, so we can add them to the calls in Classic. When retry configurations are included in the options (under the keypath `:connection` -> `:retry`), it sets up a custom retry loop on the Faraday connection. If the response is either a server error or one of a few 403 errors that indicate a temporary rate limit, it throws a custom exception that is picked up higher in the chain in the retry middleware. This loop will continue until either it succeeds, or the custom limits have been reached, at which point an error response will be returned.

See the README for config options for controlling max loop counts, intervals, backoffs, etc.

Assigning to @cap10morgan 
